### PR TITLE
Corrige mensagem de erro para unidade desconhecida

### DIFF
--- a/src/cap2-conversor/conversor.go
+++ b/src/cap2-conversor/conversor.go
@@ -22,7 +22,7 @@ func main() {
 	} else if unidadeOrigem == "quilometros" {
 		unidadeDestino = "milhas"
 	} else {
-		fmt.Printf("%s não é uma unidade conhecida!", unidadeDestino)
+		fmt.Printf("%s não é uma unidade conhecida!", unidadeOrigem)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Corrige a mensagem de erro, caso unidadeOrigem não seja celsius ou quilometros, para imprimir unidadeOrigem. Antes estava imprimindo unidadeDestino (que não possuía valor algum)
